### PR TITLE
Removed superfluous TS strict options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,12 +15,6 @@
 
     /* Strict Type-Checking Options */
     "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictPropertyInitialization": true,
-    "noImplicitThis": true,
-    // "alwaysStrict": true,
 
     /* Additional Checks */
     "noUnusedLocals": true,


### PR DESCRIPTION
"Enabling --strict enables --noImplicitAny, --noImplicitThis, --alwaysStrict, --strictBindCallApply, --strictNullChecks, --strictFunctionTypes and --strictPropertyInitialization." https://www.typescriptlang.org/docs/handbook/compiler-options.html