### PR TITLE
support inline fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4-alpha
+
+- Support inline fragment by @acro5piano
+
 ## 2.0.3-alpha
 
 - Add type inference to query alias by @acro5piano

--- a/README.md
+++ b/README.md
@@ -398,6 +398,38 @@ graphqlify.query('getMaleUser', {
 }
 ```
 
+## Inline Fragment
+
+Use `on` helper to write inline fragments.
+
+```graphql
+query getHeroForEpisode {
+  hero {
+    id
+    ... on Droid {
+      primaryFunction
+    }
+    ... on Human {
+      height
+    }
+  }
+}
+```
+
+```typescript
+graphqlify.query('getMaleUser', {
+  hero: {
+    id: types.number,
+    ...on('Droid', {
+      primaryFunction: types.string,
+    }),
+    ...on('Human', {
+      height: types.number,
+    }),
+  },
+})
+```
+
 See more examples at [`src/index.test.ts`](https://github.com/acro5piano/typed-graphqlify/blob/master/src/index.test.ts)
 
 # Why not use `apollo client:codegen`?

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ query getHeroForEpisode {
 ```
 
 ```typescript
-graphqlify.query('getMaleUser', {
+graphqlify.query('getHeroForEpisode', {
   hero: {
     id: types.number,
     ...on('Droid', {

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -369,6 +369,8 @@ describe('graphqlify', () => {
           ... on Human {
             height
           }
+        }
+      }
     `)
   })
 

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,4 +1,4 @@
-import { graphqlify, types, optional, alias } from '../index'
+import { graphqlify, types, optional, alias, on } from '../index'
 import { gql } from './test-utils'
 
 describe('graphqlify', () => {
@@ -332,6 +332,43 @@ describe('graphqlify', () => {
         user {
           id
           type
+        }
+      }
+    `)
+  })
+
+  it('render inline fragment', () => {
+    const queryObject = {
+      hero: {
+        id: types.number,
+        ...on('Droid', {
+          primaryFunction: types.string,
+        }),
+        ...on('Human', {
+          height: types.number,
+        }),
+      },
+    }
+
+    // const a: typeof queryObject = {
+    //   hero: {
+    //     id: 1,
+    //     height: 'geho',
+    //   },
+    // }
+
+    const actual = graphqlify.query('getHeroForEpisode', queryObject)
+
+    expect(actual).toEqual(gql`
+      query getHeroForEpisode {
+        hero {
+          id
+          ... on Droid {
+            primaryFunction
+          }
+          ... on Human {
+            height
+          }
         }
       }
     `)

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,5 @@
+import { Fragment, FragmentMarker } from './types'
+
 export const filterParams = (k: string) => k !== '__params'
 
 export const getParams = (params: any) => {
@@ -15,6 +17,12 @@ export const joinFieldRecursively = (fieldOrObject: any): string => {
   const joinedFields = Object.keys(fieldOrObject)
     .filter(filterParams)
     .map(key => {
+      if (key.includes(FragmentMarker)) {
+        return fieldOrObject[key].render()
+      }
+      if (fieldOrObject instanceof Fragment) {
+        return fieldOrObject.render()
+      }
       if (Array.isArray(fieldOrObject)) {
         return `${joinFieldRecursively(fieldOrObject[0])}`
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { graphqlify, alias } from './graphqlify'
-export { types, optional } from './types'
+export { types, optional, on } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,31 @@ export function optional<T>(obj: T): T | undefined {
   return obj
 }
 
+export class Fragment<T> {
+  readonly typeName: string
+  readonly fields: T
+
+  constructor(typeName: string, fields: T) {
+    this.typeName = typeName
+    this.fields = fields
+  }
+
+  render() {
+    const joinedFields = Object.keys(this.fields).join(' ')
+    //   (car, cur) => ({ ...car, [cur]: '__' }),
+    //   {},
+    // )
+    return `... on ${this.typeName} { ${joinedFields} }` as any
+  }
+}
+
+export const FragmentMarker = '__fragment__on__'
+
+export function on<T extends {}>(typeName: string, fields: T): Partial<T> {
+  const fragment = new Fragment(typeName, fields)
+  return { [`${FragmentMarker}${typeName}`]: fragment } as any
+}
+
 function constant<T extends string>(c: T): T {
   return c
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,9 +13,6 @@ export class Fragment<T> {
 
   render() {
     const joinedFields = Object.keys(this.fields).join(' ')
-    //   (car, cur) => ({ ...car, [cur]: '__' }),
-    //   {},
-    // )
     return `... on ${this.typeName} { ${joinedFields} }` as any
   }
 }


### PR DESCRIPTION
Based on https://github.com/acro5piano/typed-graphqlify/issues/9 I've added support for inline fragment.

@capaj How do you think the API?

```graphql
query getHeroForEpisode {
  hero {
    id
    ... on Droid {
      primaryFunction
    }
    ... on Human {
      height
    }
  }
}
```

```typescript
import { graphqlify, types, on } from '../index'

graphqlify.query('getHeroForEpisode', {
  hero: {
    id: types.number,
    ...on('Droid', {
      primaryFunction: types.string,
    }),
    ...on('Human', {
      height: types.number,
    }),
  },
})
```

I would like to keep the API similar to native GraphQL as possible, so this implementation is ideal to me.