### PR TITLE
Support for nested params added

### DIFF
--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -336,4 +336,26 @@ describe('graphqlify', () => {
       }
     `)
   })
+
+  it('render nested params', () => {
+    const queryObject = {
+      __params: { $param1: 'String!', $param2: 'Number' },
+      user: {
+        __params: { condition: { param1: '$param1', param2: '$param2' } },
+        id: types.number,
+        type: types.string,
+      },
+    }
+
+    const actual = graphqlify.query('getUser', queryObject)
+
+    expect(actual).toEqual(gql`
+      query getUser($param1: String!, $param2: Number) {
+        user(condition: { param1: $param1, param2: $param2 }) {
+          id
+          type
+        }
+      }
+    `)
+  })
 })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,14 +1,12 @@
 export const filterParams = (k: string) => k !== '__params'
 
-export const getParams = (params: any) => {
-  if (!params) {
-    return ''
-  }
-  const variables = Object.keys(params)
-    .map(key => `${key}: ${params[key]}`)
+const nestParams = (params: any): any =>
+  typeof params === 'object' ? `{ ${serializeParams(params)} }` : params
+const serializeParams = (params: any) =>
+  Object.keys(params)
+    .map(key => `${key}: ${nestParams(params[key])}`)
     .join(', ')
-  return `(${variables})`
-}
+export const getParams = (params: any) => (params ? `(${serializeParams(params)})` : '')
 
 // TODO: Tail Call Recursion
 export const joinFieldRecursively = (fieldOrObject: any): string => {


### PR DESCRIPTION
This pull requests adds serialization of nested parameters. Without this, objects would be serialized to `[Object object]` in the output string.