### PR TITLE
add custom scalar property

### DIFF
--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -274,19 +274,42 @@ describe('graphqlify', () => {
     }
     const actual = graphqlify.query('getUsers', queryObject)
 
-    // just type check
+    expect(actual).toEqual(gql`
+      query getUsers {
+        users {
+          id
+          __typename
+        }
+      }
+    `)
+  })
+
+  it('render custom scalar property', () => {
+    interface CustomField {
+      id: number
+    }
+
+    const queryObject = {
+      users: {
+        id: types.number,
+        customField: types.custom<CustomField>(),
+      },
+    }
+    const actual = graphqlify.query('getUsers', queryObject)
+
+    // the following will cause error because `CustomField` needs `{ id: number }`
     // const a: typeof queryObject = {
     //   users: {
-    //     id: 1,
-    //     __typename: 'User',
-    //   },
+    //     id:1,
+    //     customField: {},
+    //   }
     // }
 
     expect(actual).toEqual(gql`
       query getUsers {
         users {
           id
-          __typename
+          customField
         }
       }
     `)

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -297,14 +297,6 @@ describe('graphqlify', () => {
     }
     const actual = graphqlify.query('getUsers', queryObject)
 
-    // the following will cause error because `CustomField` needs `{ id: number }`
-    // const a: typeof queryObject = {
-    //   users: {
-    //     id:1,
-    //     customField: {},
-    //   }
-    // }
-
     expect(actual).toEqual(gql`
       query getUsers {
         users {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,10 @@ function constant<T extends string>(c: T): T {
   return c
 }
 
+function custom<T>(): T {
+  return '' as any
+}
+
 function oneOf<T extends {}>(e: T): keyof T {
   return Object.keys(e)[0] as keyof T
 }
@@ -17,4 +21,5 @@ export class types {
   static optional: Partial<typeof types> = types
   static constant = constant
   static oneOf = oneOf
+  static custom = custom
 }


### PR DESCRIPTION
https://github.com/acro5piano/typed-graphqlify/issues/33

A note for type check:

```ts
    const queryObject = {
      users: {
        id: types.number,
        customField: types.custom<CustomField>(),
      },
    }

    // the following will cause error because `CustomField` needs `{ id: number }`
    const a: typeof queryObject = {
      users: {
        id:1,
        customField: {},
      }
    }
```