### PR TITLE
Bugfix: Nested fragment objects

### DIFF
--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -389,6 +389,62 @@ describe('graphqlify', () => {
     `)
   })
 
+  it('render nested inline fragment', () => {
+    const queryObject = {
+      hero: {
+        id: types.number,
+        ...on('Droid', {
+          internalData: {
+            memory: types.number,
+            parts: {
+              ...on('Cpu', {
+                instuctionSet: types.string,
+              }),
+              ...on('HDD', {
+                size: types.number,
+                diagnostics: {
+                  maxRpm: types.number,
+                },
+              }),
+            },
+          },
+        }),
+        ...on('Human', {
+          height: types.number,
+        }),
+      },
+    }
+
+    const actual = graphqlify.query('getHeroForEpisode', queryObject)
+
+    expect(actual).toEqual(gql`
+      query getHeroForEpisode {
+        hero {
+          id
+          ... on Droid {
+            internalData {
+              memory
+              parts {
+                ... on Cpu {
+                  instuctionSet
+                }
+                ... on HDD {
+                  size
+                  diagnostics {
+                    maxRpm
+                  }
+                }
+              }
+            }
+          }
+          ... on Human {
+            height
+          }
+        }
+      }
+    `)
+  })
+
   it('render nested params', () => {
     const queryObject = {
       __params: { $param1: 'String!', $param2: 'Number' },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,19 @@
-import { Fragment, FragmentMarker } from './types'
+export class Fragment<T> {
+  readonly typeName: string
+  readonly fields: T
+
+  constructor(typeName: string, fields: T) {
+    this.typeName = typeName
+    this.fields = fields
+  }
+
+  render() {
+    const joinedFields = joinFieldRecursively(this.fields)
+    return `... on ${this.typeName} { ${joinedFields} }` as any
+  }
+}
+
+export const FragmentMarker = '__fragment__on__'
 
 export const filterParams = (k: string) => k !== '__params'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,23 +1,8 @@
+import { Fragment, FragmentMarker } from './helpers'
+
 export function optional<T>(obj: T): T | undefined {
   return obj
 }
-
-export class Fragment<T> {
-  readonly typeName: string
-  readonly fields: T
-
-  constructor(typeName: string, fields: T) {
-    this.typeName = typeName
-    this.fields = fields
-  }
-
-  render() {
-    const joinedFields = Object.keys(this.fields).join(' ')
-    return `... on ${this.typeName} { ${joinedFields} }` as any
-  }
-}
-
-export const FragmentMarker = '__fragment__on__'
 
 export function on<T extends {}>(typeName: string, fields: T): Partial<T> {
   const fragment = new Fragment(typeName, fields)


### PR DESCRIPTION
This fixes fragments not rendering nested fields (as this is a blocker on what I'm working on currently).

Example query:

```ts
console.log(graphqlify.query({
  hero: {
    ...on('TestObject', {
      field: {
        nesedField: types.string,
      },
    }),
  },
}));
```
Currently outputs:

```gql
query { hero { ... on TestObject { field } } }
```

Now outputs:

```gql
query { hero { ... on TestObject { field { nestedField } } } }
```

Just a note, I moved the `Fragment` class and `FragmentMarker` constant to `helpers.ts`, since it prevents a circular import (which could be annoying possibly? It's less readable at least).