### PR TITLE
Added union fragment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,55 @@ query('getHeroForEpisode', {
 })
 ```
 
+If you are using a discriminated union pattern, then you can use the `onUnion` helper, which will automatically generate the union type for you:
+
+```graphql
+query getHeroForEpisode {
+  hero {
+    id
+    ... on Droid {
+      primaryFunction
+    }
+    ... on Human {
+      height
+    }
+  }
+}
+```
+
+```typescript
+import { onUnion, query, types } from 'typed-graphqlify'
+
+query('getHeroForEpisode', {
+  hero: {
+    id: types.number,
+    ...onUnion({
+      Droid: {
+        kind: types.constant('Droid'),
+        primaryFunction: types.string,
+      },
+      Human: {
+        kind: types.constant('Human'),
+        height: types.number,
+      },
+    }),
+  },
+})
+```
+
+This function will return a type of `A | B`, meaning that you can use the following logic to differentiate between the 2 types:
+
+```typescript
+const droidOrHuman = queryResult.hero
+if (droidOrHuman.kind === 'Droid') {
+  const droid = droidOrHuman
+  /// ... handle droid
+} else if (droidOrHument.kind === 'Human') {
+  const human = droidOrHuman
+  /// ... handle human
+}
+```
+
 See more examples at [`src/index.test.ts`](https://github.com/acro5piano/typed-graphqlify/blob/master/src/index.test.ts)
 
 # Why not use `apollo client:codegen`?

--- a/README.md
+++ b/README.md
@@ -530,9 +530,11 @@ query getHeroForEpisode {
   hero {
     id
     ... on Droid {
+      kind
       primaryFunction
     }
     ... on Human {
+      kind
       height
     }
   }
@@ -565,10 +567,10 @@ This function will return a type of `A | B`, meaning that you can use the follow
 const droidOrHuman = queryResult.hero
 if (droidOrHuman.kind === 'Droid') {
   const droid = droidOrHuman
-  /// ... handle droid
+  // ... handle droid
 } else if (droidOrHument.kind === 'Human') {
   const human = droidOrHuman
-  /// ... handle human
+  // ... handle human
 }
 ```
 

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -1,6 +1,16 @@
-import { params, fragment, query, mutation, types, optional, alias, on, rawString } from '../index'
+import {
+  params,
+  fragment,
+  query,
+  mutation,
+  types,
+  optional,
+  alias,
+  on,
+  rawString,
+  onUnion,
+} from '../index'
 import { gql } from './test-utils'
-import { onUnion } from 'app/types'
 
 describe('graphqlify', () => {
   it('render GraphQL', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { fragment, params, query, mutation, subscription, alias, rawString } from './graphqlify'
-export { types, optional, on } from './types'
+export { types, optional, on, onUnion } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,17 @@ export function on<T extends {}>(typeName: string, internal: T): Partial<T> {
   return { [Symbol(`InlineFragment(${typeName})`)]: fragment } as any
 }
 
+export function onUnion<T>(types: Record<string, T>): T {
+  let fragments: Record<any, T> = {}
+  for (const [typeName, internal] of Object.entries(types)) {
+    fragments = {
+      ...fragments,
+      ...on(typeName, internal),
+    }
+  }
+  return fragments as any
+}
+
 function scalarType(): any {
   const scalar: GraphQLScalar = {
     [typeSymbol]: GraphQLType.SCALAR,


### PR DESCRIPTION
Closes #40. Uses the suggested syntax
```ts
const query = query({
  ...onUnion({ 
      ObjA: {
        name: types.constant('a'),
        prop: types.string,
      },
      ObjB: {
        name: types.constant('b'),
        field: types.number,
      },
  }),
})
```