### PR TITLE
Fix rollup config: exluding 'tslib'

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,10 +2,9 @@ src
 examples
 coverage
 docs
+*.jpg
 *.png
 *.log
-jest.config.js
-tsconfig.json
 CONTRIBUTING.md
 ISSUE_TEMPLATE.md
 PULL_REQUEST_TEMPLATE.md
@@ -16,5 +15,7 @@ tslint.json
 .publishrc
 .rpt2_cache
 
+jest.config.js
+tsconfig.json
+tslint.json
 prettier.config.js
-screenshot.jpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.1
+
+- Fix rollup config: exluding 'tslib' by @acro5piano
+
 ## 2.2.0
 
 - union fragment support by @luvies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-graphqlify",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Build Typed GraphQL Queries in TypeScript. A better TypeScript + GraphQL experience.",
   "keywords": [
     "graphql",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default {
       declaration: true,
     }),
   ],
-  external: id => !id.startsWith('.') && !id.startsWith('/'),
+  external: id => !id.startsWith('.') && !id.startsWith('/') && id !== 'tslib',
   output: [
     {
       file: 'dist/index.js',


### PR DESCRIPTION
On React Native, the following error occurs:

```
"message":"Unable to resolve module `tslib`
from `app/node_modules/typed-graphqlify/dist/index.js`:
Module `tslib` does not exist in the Haste module map

This might be related to https://github.com/facebook/react-native/issues/4968
```