### PR TITLE
use `ValueOf<T>` instead of `keyof T` in types.enum

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
 import { typeSymbol, GraphQLType, GraphQLScalar, GraphQLInlineFragment } from './render'
 
+// Utility type
+type ValueOf<T> = T[keyof T]
+
 export function optional<T>(obj: T): T | undefined {
   return obj
 }
@@ -48,7 +51,7 @@ export class types {
     return scalarType()
   }
 
-  static oneOf<T extends {}>(_e: T): keyof T {
+  static oneOf<T extends {}>(_e: T): ValueOf<T> {
     return scalarType()
   }
 
@@ -61,7 +64,7 @@ export class types {
     string?: string
     boolean?: boolean
     constant: <T extends string>(_c: T) => T | undefined
-    oneOf: <T extends {}>(_e: T) => (keyof T) | undefined
+    oneOf: <T extends {}>(_e: T) => (ValueOf<T>) | undefined
     custom: <T>() => T | undefined
   } = types
 }


### PR DESCRIPTION
When we write the following object, TypeScript says `Type 'UserType.Student' is not assignable to type '"Student" | "Teacher"'. `

```typescript
enum UserType {
  'Student',
  'Teacher',
}

const queryObject = {
  user: {
    id: types.number,
    type: types.oneOf(UserType),
  },
}

const a: typeof queryObject = {
  user: {
    id: 1,
    type: UserType.Student,
  },
}
```

Actually `UserType.Student` is `0` in this case, because TypeScript's enum values are set to numbers if no values given.

This patch will fix it.