### PR TITLE
Add QueryObject and CompiledResult to index.ts

### DIFF
--- a/src/graphqlify.ts
+++ b/src/graphqlify.ts
@@ -1,10 +1,10 @@
 import { GraphQLFragment, GraphQLType, Params, paramsSymbol, render, typeSymbol } from './render'
 
-interface QueryObject {
+export interface QueryObject {
   [x: string]: any
 }
 
-interface CompiledResult<D, V> {
+export interface CompiledResult<D, V> {
   toString: () => string
   data: D
   variable: V

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { fragment, params, query, mutation, subscription, alias, rawString } from './graphqlify'
+export { fragment, params, query, mutation, subscription, alias, rawString, QueryObject, CompiledResult } from './graphqlify'
 export { types, optional, on, onUnion } from './types'
 export { fragmentToString } from './render'


### PR DESCRIPTION
Hi. I'd like to add QueryObject and CompiledResult to index.ts.
Without them I cannot build declaration files in my project, when using typed-graphqlify.

In code like this
```
import { query, types } from 'typed-graphqlify';

export const clientQuery = query({
  client: {
    id: types.number,
    name: types.string,
    isActive: types.boolean,
  },
});
```

I'm getting error
Exported variable 'clientQuery' has or is using name 'CompiledResult' from external module "/home/goremykin/Projects/call-center-portal-api/node_modules/typed-graphqlify/dist/graphqlify" but cannot be named. ts(4023)