### PR TITLE
Remove typescript as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,6 @@
     "test:coverage": "jest --coverage",
     "prepublish": "npm run dist"
   },
-  "dependencies": {},
-  "peerDependencies": {
-    "typescript": "^4.0.2"
-  },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
   },


### PR DESCRIPTION
Trying to upgrade to node 18, npm now has a tighter check for peer dependencies.

It looks like typescript was added as a peer dependency, but is not actually needed as a peer dependecy, therefore removing it :)